### PR TITLE
add web tests

### DIFF
--- a/lib/src/usage_impl_html.dart
+++ b/lib/src/usage_impl_html.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library usage_impl_html;
+
+import 'dart:async';
+import 'dart:convert' show JSON;
+import 'dart:html';
+
+import 'usage_impl.dart';
+
+class HtmlPostHandler extends PostHandler {
+  final Function mockRequestor;
+
+  HtmlPostHandler({Function this.mockRequestor});
+
+  Future sendPost(String url, Map<String, String> parameters) {
+    int viewportWidth = document.documentElement.clientWidth;
+    int viewportHeight = document.documentElement.clientHeight;
+
+    parameters['vp'] = '${viewportWidth}x$viewportHeight';
+
+    String data = postEncode(parameters);
+    var request = mockRequestor == null ? HttpRequest.request : mockRequestor;
+    return request(url, method: 'POST', sendData: data).catchError((e) {
+      // Catch errors that can happen during a request, but that we can't do
+      // anything about, e.g. a missing internet conenction.
+    });
+  }
+}
+
+class HtmlPersistentProperties extends PersistentProperties {
+  Map _map;
+
+  HtmlPersistentProperties(String name) : super(name) {
+    String str = window.localStorage[name];
+    if (str == null || str.isEmpty) str = '{}';
+    _map = JSON.decode(str);
+  }
+
+  dynamic operator[](String key) => _map[key];
+
+  void operator[]=(String key, dynamic value) {
+    if (value == null) {
+      _map.remove(key);
+    } else {
+      _map[key] = value;
+    }
+
+    window.localStorage[name] = JSON.encode(_map);
+  }
+}

--- a/lib/usage_html.dart
+++ b/lib/usage_html.dart
@@ -11,11 +11,10 @@
  */
 library usage_html;
 
-import 'dart:async';
-import 'dart:convert' show JSON;
 import 'dart:html';
 
 import 'src/usage_impl.dart';
+import 'src/usage_impl_html.dart';
 
 export 'usage.dart';
 
@@ -26,8 +25,8 @@ class AnalyticsHtml extends AnalyticsImpl {
   AnalyticsHtml(String trackingId, String applicationName, String applicationVersion) :
     super(
       trackingId,
-      new _PersistentProperties(applicationName),
-      new _PostHandler(),
+      new HtmlPersistentProperties(applicationName),
+      new HtmlPostHandler(),
       applicationName: applicationName,
       applicationVersion: applicationVersion) {
     int screenWidth = window.screen.width;
@@ -36,45 +35,5 @@ class AnalyticsHtml extends AnalyticsImpl {
     setSessionValue('sr', '${screenWidth}x$screenHeight');
     setSessionValue('sd', '${window.screen.pixelDepth}-bits');
     setSessionValue('ul', window.navigator.language);
-  }
-}
-
-class _PostHandler extends PostHandler {
-  Future sendPost(String url, Map<String, String> parameters) {
-    int viewportWidth = document.documentElement.clientWidth;
-    int viewportHeight = document.documentElement.clientHeight;
-
-    parameters['vp'] = '${viewportWidth}x$viewportHeight';
-
-    String data = postEncode(parameters);
-    return HttpRequest.request(
-        url,
-        method: 'POST',
-        sendData: data).catchError((e) {
-      // Catch errors that can happen during a request, but that we can't do
-      // anything about, e.g. a missing internet conenction.
-    });
-  }
-}
-
-class _PersistentProperties extends PersistentProperties {
-  Map _map;
-
-  _PersistentProperties(String name) : super(name) {
-    String str = window.localStorage[name];
-    if (str == null || str.isEmpty) str = '{}';
-    _map = JSON.decode(str);
-  }
-
-  dynamic operator[](String key) => _map[key];
-
-  void operator[]=(String key, dynamic value) {
-    if (value == null) {
-      _map.remove(key);
-    } else {
-      _map[key] = value;
-    }
-
-    window.localStorage[name] = JSON.encode(_map);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ homepage: https://github.com/dart-lang/usage
 author: Dart Team <misc@dartlang.org>
 
 dependencies:
-  crypto: '>=0.9.0 <0.10.0'
   uuid: '>=0.4.0 <0.5.0'
 
 dev_dependencies:
+  browser: any
   unittest: '>=0.11.0 <0.12.0'

--- a/test/web.html
+++ b/test/web.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<!-- Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+     for details. All rights reserved. Use of this source code is governed by a
+     BSD-style license that can be found in the LICENSE file. -->
+
+<html>
+  <head>
+  	<meta charset="utf-8">
+  	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Usage Tests</title>
+  </head>
+
+  <body>
+    <script src="packages/unittest/test_controller.js"></script>
+    <script type="application/dart" src="web_test.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>

--- a/test/web_test.dart
+++ b/test/web_test.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library usage.web_test;
+
+import 'dart:async';
+
+import 'package:usage/src/usage_impl_html.dart';
+import 'package:unittest/html_config.dart';
+import 'package:unittest/unittest.dart';
+
+import 'hit_types_test.dart' as hit_types_test;
+import 'usage_test.dart' as usage_test;
+import 'usage_impl_test.dart' as usage_impl_test;
+
+// TODO: get the tests running in content_shell
+
+void main() {
+  // Set up the test environment.
+  useHtmlConfiguration();
+
+  // Define the tests.
+  hit_types_test.defineTests();
+  usage_test.defineTests();
+  usage_impl_test.defineTests();
+
+  // Define some web specfic tests.
+  defineWebTests();
+}
+
+void defineWebTests() {
+  group('HtmlPostHandler', () {
+    test('sendPost', () {
+      MockRequestor client = new MockRequestor();
+      HtmlPostHandler postHandler = new HtmlPostHandler(
+          mockRequestor: client.request);
+      Map args = {'utv': 'varName', 'utt': 123};
+      return postHandler.sendPost('http://www.google.com', args).then((_) {
+        expect(client.sendCount, 1);
+      });
+    });
+  });
+
+  group('HtmlPersistentProperties', () {
+    test('add', () {
+      HtmlPersistentProperties props = new HtmlPersistentProperties('foo_props');
+      props['foo'] = 'bar';
+      expect(props['foo'], 'bar');
+    });
+
+    test('remove', () {
+      HtmlPersistentProperties props = new HtmlPersistentProperties('foo_props');
+      props['foo'] = 'bar';
+      expect(props['foo'], 'bar');
+      props['foo'] = null;
+      expect(props['foo'], null);
+    });
+  });
+}
+
+class MockRequestor {
+  int sendCount = 0;
+
+  Future request(String url, {String method, String sendData}) {
+    expect(url, isNotEmpty);
+    expect(method, isNotEmpty);
+    expect(sendData, isNotEmpty);
+
+    sendCount++;
+    return new Future.value();
+  }
+}


### PR DESCRIPTION
Add tests to validate the usage library running in a dart:html context. Will need to follow this up with CLs to get the tests running on our CI bot, and to replace the uuid package, to minimize the compiled JS size of apps using this library.

Fix https://github.com/dart-lang/usage/issues/30.
