### PR TITLE
added a utility method to time async events

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## TODO
 - Added a web example
+- Added a utility method to time async events (`Analytics.startTimer()`)
 
 ## 0.0.5
 

--- a/example/example.html
+++ b/example/example.html
@@ -25,9 +25,9 @@
 
   <body>
     <h3>Usage library example</h3>
-    
+
     <input id="ua" type="text" value="UA-55029513-1">
-    
+
     <div class="row">
       <button id="foo">Fire 'foo' event</button>
 
@@ -35,7 +35,7 @@
 
       <button id="page">Change page</button>
     </div>
-    
+
     <script type="application/dart" src="example.dart"></script>
     <script src="packages/browser/dart.js"></script>
   </body>

--- a/lib/src/usage_impl.dart
+++ b/lib/src/usage_impl.dart
@@ -119,6 +119,11 @@ abstract class AnalyticsImpl implements Analytics {
     return _sendPayload('timing', args);
   }
 
+  AnalyticsTimer startTimer(String variableName, {String category, String label}) {
+    return new AnalyticsTimer(this,
+        variableName, category: category, label: label);
+  }
+
   Future sendException(String description, {bool fatal}) {
     if (!optIn) return new Future.value();
 

--- a/test/hit_types_test.dart
+++ b/test/hit_types_test.dart
@@ -4,6 +4,9 @@
 
 library usage.hit_types_test;
 
+import 'dart:async';
+
+import 'package:usage/usage.dart';
 import 'package:unittest/unittest.dart';
 
 import 'src/common.dart';
@@ -71,6 +74,24 @@ void defineTests() {
       has(mock.last, 'utt');
       has(mock.last, 'utc');
       has(mock.last, 'utl');
+    });
+
+    test('timer', () {
+      AnalyticsImplMock mock = createMock();
+      AnalyticsTimer timer =
+          mock.startTimer('compile', category: 'Build', label: 'Compile');
+
+      return new Future.delayed(new Duration(milliseconds: 20), () {
+        return timer.finish().then((_) {
+          expect(mock.mockPostHandler.sentValues, isNot(isEmpty));
+          was(mock.last, 'timing');
+          has(mock.last, 'utv');
+          has(mock.last, 'utt');
+          has(mock.last, 'utc');
+          has(mock.last, 'utl');
+          expect(timer.currentElapsedMillis, greaterThan(10));
+        });
+      });
     });
   });
 

--- a/test/hit_types_test.dart
+++ b/test/hit_types_test.dart
@@ -81,6 +81,8 @@ void defineTests() {
       AnalyticsTimer timer =
           mock.startTimer('compile', category: 'Build', label: 'Compile');
 
+      int time;
+
       return new Future.delayed(new Duration(milliseconds: 20), () {
         return timer.finish().then((_) {
           expect(mock.mockPostHandler.sentValues, isNot(isEmpty));
@@ -89,7 +91,11 @@ void defineTests() {
           has(mock.last, 'utt');
           has(mock.last, 'utc');
           has(mock.last, 'utl');
-          expect(timer.currentElapsedMillis, greaterThan(10));
+          int time = timer.currentElapsedMillis;
+          expect(time, greaterThan(10));
+          return new Future.delayed(new Duration(milliseconds: 10), () {
+            expect(timer.currentElapsedMillis, time);
+          });
         });
       });
     });

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -15,6 +15,7 @@ void defineTests() {
       mock.sendEvent('files', 'save');
       mock.sendSocial('g+', 'plus', 'userid');
       mock.sendTiming('compile', 123);
+      mock.startTimer('compile').finish();
       mock.sendException('FooException');
       mock.setSessionValue('val', 'ue');
     });


### PR DESCRIPTION
fix #9, added a utility method to time async events (`Analytics.startTimer()`).