### PR TITLE
switch to using the dart configuration for travis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,13 +24,13 @@ Google Analytics can cause the tool to pause for several seconds before it
 terminates. This is often undesired - gathering analytics information shouldn't
 negatively effect the tool's UX.
 
-One solution to this is to use the `waitForLastPing(Duration timeout)` method
+One solution to this is to use the `waitForLastPing({Duration timeout})` method
 on the analytics object. This will wait until all outstanding analytics requests
 have completed, or until the specified duration has elapsed. So, CLI apps can do
 something like:
 
 ```dart
-analytics.waitForLastPing(new Duration(milliseconds: 500)).then((_) {
+analytics.waitForLastPing(timeout: new Duration(milliseconds: 500)).then((_) {
   exit(0);
 });
 ```
@@ -39,7 +39,9 @@ analytics.waitForLastPing(new Duration(milliseconds: 500)).then((_) {
 
 Import the package (in this example we use the `dart:io` version):
 
-    import 'package:usage/usage_io.dart';
+```dart
+import 'package:usage/usage_io.dart';
+```
 
 And call some analytics code:
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -7,20 +7,6 @@
 # Fast fail the script on failures.
 set -e
 
-# Get the Dart SDK.
-DART_DIST=dartsdk-linux-x64-release.zip
-curl http://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/$DART_DIST > $DART_DIST
-unzip $DART_DIST > /dev/null
-rm $DART_DIST
-export DART_SDK="$PWD/dart-sdk"
-export PATH="$DART_SDK/bin:$PATH"
-
-# Display installed versions.
-dart --version
-
-# Get our packages.
-pub get
-
 # Verify that the libraries are error free.
 dartanalyzer --fatal-warnings \
   lib/usage.dart \


### PR DESCRIPTION
Switch `usage` to use the new Travis Dart configuration.