### PR TITLE
add a analyticsUrl parameter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+- added an optional `analyticsUrl` parameter to the usage constructors
+
 ## 1.1.0
 - fix two strong mode analysis issues (overrridding a field declaration with a
   setter/getter pair)

--- a/lib/src/usage_impl.dart
+++ b/lib/src/usage_impl.dart
@@ -61,7 +61,7 @@ class ThrottlingBucket {
 }
 
 abstract class AnalyticsImpl extends Analytics {
-  static const String _GA_URL = 'https://www.google-analytics.com/collect';
+  static const String _defaultAnalyticsUrl = 'https://www.google-analytics.com/collect';
 
   /// Tracking ID / Property ID.
   final String trackingId;
@@ -74,12 +74,22 @@ abstract class AnalyticsImpl extends Analytics {
 
   final List<Future> _futures = [];
 
-  AnalyticsImpl(this.trackingId, this.properties, this.postHandler,
-      {String applicationName, String applicationVersion}) {
+  String _url;
+
+  AnalyticsImpl(
+    this.trackingId,
+    this.properties,
+    this.postHandler, {
+    String applicationName,
+    String applicationVersion,
+    String analyticsUrl
+  }) {
     assert(trackingId != null);
 
     if (applicationName != null) setSessionValue('an', applicationName);
     if (applicationVersion != null) setSessionValue('av', applicationVersion);
+
+    _url = analyticsUrl ?? _defaultAnalyticsUrl;
   }
 
   bool get optIn => properties['optIn'] == true;
@@ -189,7 +199,7 @@ abstract class AnalyticsImpl extends Analytics {
       args['cid'] = _clientId;
       args['t'] = hitType;
 
-      return _recordFuture(postHandler.sendPost(_GA_URL, args));
+      return _recordFuture(postHandler.sendPost(_url, args));
     } else {
       return new Future.value();
     }

--- a/lib/usage_html.dart
+++ b/lib/usage_html.dart
@@ -20,15 +20,21 @@ export 'usage.dart';
 
 /**
  * An interface to a Google Analytics session, suitable for use in web apps.
+ *
+ * [analyticsUrl] is an optional replacement for the default Google Analytics
+ * URL (`https://www.google-analytics.com/collect`).
  */
 class AnalyticsHtml extends AnalyticsImpl {
-  AnalyticsHtml(String trackingId, String applicationName, String applicationVersion) :
-    super(
+  AnalyticsHtml(String trackingId, String applicationName, String applicationVersion, {
+    String analyticsUrl
+  }) : super(
       trackingId,
       new HtmlPersistentProperties(applicationName),
       new HtmlPostHandler(),
       applicationName: applicationName,
-      applicationVersion: applicationVersion) {
+      applicationVersion: applicationVersion,
+      analyticsUrl: analyticsUrl
+  ) {
     int screenWidth = window.screen.width;
     int screenHeight = window.screen.height;
 

--- a/lib/usage_io.dart
+++ b/lib/usage_io.dart
@@ -19,13 +19,19 @@ export 'usage.dart';
 /**
  * An interface to a Google Analytics session, suitable for use in command-line
  * applications.
+ *
+ * [analyticsUrl] is an optional replacement for the default Google Analytics
+ * URL (`https://www.google-analytics.com/collect`).
  */
 class AnalyticsIO extends AnalyticsImpl {
-  AnalyticsIO(String trackingId, String applicationName, String applicationVersion) :
-    super(
-      trackingId,
-      new IOPersistentProperties(applicationName),
-      new IOPostHandler(),
-      applicationName: applicationName,
-      applicationVersion: applicationVersion);
+  AnalyticsIO(String trackingId, String applicationName, String applicationVersion, {
+    String analyticsUrl
+  }) : super(
+    trackingId,
+    new IOPersistentProperties(applicationName),
+    new IOPostHandler(),
+    applicationName: applicationName,
+    applicationVersion: applicationVersion,
+    analyticsUrl: analyticsUrl
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: usage
-version: 1.1.0
+version: 1.2.0
 description: A Google Analytics wrapper for both command-line and web apps.
 homepage: https://github.com/dart-lang/usage
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
- added an optional `analyticsUrl` parameter to the usage constructors
- fix https://github.com/dart-lang/usage/issues/60