### PR TITLE
use the newer Flutter sdk reference style

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,7 +1,4 @@
 analyzer:
   strong-mode: true
-  language:
-    enableConditionalDirectives: true
   exclude:
-    - example/flutter_example/**
     - lib/src/usage_impl_flutter.dart

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## unreleased
+- updated the Flutter example pubspec to use the newer Flutter sdk reference style
+
 ## 2.2.2
 - adjust the Flutter usage client to Flutter API changes
 

--- a/example/flutter_example/lib/main.dart
+++ b/example/flutter_example/lib/main.dart
@@ -15,7 +15,7 @@ Future main() async {
     theme: new ThemeData.dark(),
     routes: <String, WidgetBuilder>{
       '/': (BuildContext context) => new FlutterDemo(ga)
-    }
+    },
   ));
 }
 
@@ -46,28 +46,28 @@ class _FlutterDemoState extends State<FlutterDemo> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text('Usage Example')
+        title: new Text('Usage Example'),
       ),
       body: new Column(
         children: <Widget>[
           new Center(
-            child: new Text("Button pressed $_times times.")
+            child: new Text("Button pressed $_times times."),
           ),
           new ListItem(
             onTap: () => _handleOptIn(!config.ga.enabled),
             leading: new Checkbox(
               value: config.ga.enabled,
-              onChanged: _handleOptIn
+              onChanged: _handleOptIn,
             ),
-            title: new Text("Opt in to analytics")
-          )
+            title: new Text("Opt in to analytics"),
+          ),
         ],
-        mainAxisAlignment: MainAxisAlignment.spaceAround
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
       ),
       floatingActionButton: new FloatingActionButton(
-        child: new Icon(icon: Icons.add),
-        onPressed: _handleButtonPressed
-      )
+        child: new Icon(Icons.add),
+        onPressed: _handleButtonPressed,
+      ),
     );
   }
 }

--- a/example/flutter_example/pubspec.yaml
+++ b/example/flutter_example/pubspec.yaml
@@ -1,7 +1,12 @@
 name: flutter_example
 description: Create a new Flutter project.
+
+environment:
+  sdk: ">=1.19.0 <2.0.0"
+  flutter: ^0.0.1
+
 dependencies:
   usage:
     path: ../..
   flutter:
-    path: ../../../flutter/packages/flutter
+    sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,13 +3,13 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: usage
-version: 2.2.2
+version: 3.0.0-dev.1
 description: A Google Analytics wrapper for both command-line, web, and Flutter apps.
 homepage: https://github.com/dart-lang/usage
 author: Dart Team <misc@dartlang.org>
 
 environment:
-  sdk: '>=1.15.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 
 dev_dependencies:
   browser: ^0.10.0


### PR DESCRIPTION
- update the `usage` package to use the newer Flutter sdk reference style
- use trailing commas in the flutter example

@danrubel @pq 