### PR TITLE
Remove getPlatformLocale test

### DIFF
--- a/test/usage_impl_io_test.dart
+++ b/test/usage_impl_io_test.dart
@@ -41,10 +41,6 @@ void defineTests() {
   });
 
   group('usage_impl_io', () {
-    test('getPlatformLocale', () {
-      expect(getPlatformLocale(), isNotNull);
-    });
-
     test('getDartVersion', () {
       expect(getDartVersion(), isNotNull);
     });


### PR DESCRIPTION
This test doesn't pass on systems that do not have a locale.