### PR TITLE
Add path dependency.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,9 @@ author: Dart Team <misc@dartlang.org>
 environment:
   sdk: '>=1.19.0 <2.0.0'
 
+dependencies:
+  path: ^1.4.0
+
 dev_dependencies:
   browser: ^0.10.0
   grinder: ^0.8.0


### PR DESCRIPTION
`usage` already depends on `path` (see `usage_impl_io.dart`); this
just records that fact correctly.