### PR TITLE
make clientId public

### DIFF
--- a/lib/src/usage_impl.dart
+++ b/lib/src/usage_impl.dart
@@ -199,13 +199,11 @@ class AnalyticsImpl implements Analytics {
     return f;
   }
 
-  /**
-   * Anonymous Client ID. The value of this field should be a random UUID v4.
-   */
-  String get _clientId => properties['clientId'];
+  @override
+  String get clientId => properties['clientId'];
 
   void _initClientId() {
-    if (_clientId == null) {
+    if (clientId == null) {
       properties['clientId'] = new Uuid().generateV4();
     }
   }
@@ -237,7 +235,7 @@ class AnalyticsImpl implements Analytics {
 
       args['v'] = '1'; // protocol version
       args['tid'] = trackingId;
-      args['cid'] = _clientId;
+      args['cid'] = clientId;
       args['t'] = hitType;
 
       _sendController.add(args);

--- a/lib/usage.dart
+++ b/lib/usage.dart
@@ -68,6 +68,14 @@ abstract class Analytics {
   set enabled(bool value);
 
   /**
+   * Anonymous client ID in UUID v4 format.
+   *
+   * The value is randomly-generated and should be reasonably stable for the
+   * computer sending analytics data.
+   */
+  String get clientId;
+
+  /**
    * Sends a screen view hit to Google Analytics.
    */
   Future sendScreenView(String viewName);
@@ -224,6 +232,9 @@ class AnalyticsMock implements Analytics {
   AnalyticsOpt analyticsOpt = AnalyticsOpt.optOut;
 
   bool enabled = true;
+
+  @override
+  String get clientId => '00000000-0000-4000-0000-000000000000';
 
   Future sendScreenView(String viewName) =>
       _log('screenView', {'viewName': viewName});


### PR DESCRIPTION
This is so we could use the same stable client ID for crash reporting.