### PR TITLE
Changes for landing https://github.com/dart-lang/sdk/issues/32161

### DIFF
--- a/test/hit_types_test.dart
+++ b/test/hit_types_test.dart
@@ -11,7 +11,7 @@ import 'package:usage/usage.dart';
 
 import 'src/common.dart';
 
-main() => defineTests();
+void main() => defineTests();
 
 void defineTests() {
   group('screenView', () {

--- a/test/src/common.dart
+++ b/test/src/common.dart
@@ -12,9 +12,9 @@ import 'package:usage/src/usage_impl.dart';
 AnalyticsImplMock createMock({Map<String, dynamic> props}) =>
     new AnalyticsImplMock('UA-0', props: props);
 
-was(Map m, String type) => expect(m['t'], type);
-has(Map m, String key) => expect(m[key], isNotNull);
-hasnt(Map m, String key) => expect(m[key], isNull);
+void was(Map m, String type) => expect(m['t'], type);
+void has(Map m, String key) => expect(m[key], isNotNull);
+void hasnt(Map m, String key) => expect(m[key], isNull);
 
 class AnalyticsImplMock extends AnalyticsImpl {
   MockProperties get mockProperties => properties;

--- a/test/usage_impl_io_test.dart
+++ b/test/usage_impl_io_test.dart
@@ -11,7 +11,7 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:usage/src/usage_impl_io.dart';
 
-main() => defineTests();
+void main() => defineTests();
 
 void defineTests() {
   group('IOPostHandler', () {

--- a/test/usage_impl_test.dart
+++ b/test/usage_impl_test.dart
@@ -9,7 +9,7 @@ import 'package:usage/src/usage_impl.dart';
 
 import 'src/common.dart';
 
-main() => defineTests();
+void main() => defineTests();
 
 void defineTests() {
   group('ThrottlingBucket', () {

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -7,7 +7,7 @@ library usage.usage_test;
 import 'package:test/test.dart';
 import 'package:usage/usage.dart';
 
-main() => defineTests();
+void main() => defineTests();
 
 void defineTests() {
   group('AnalyticsMock', () {

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -7,7 +7,7 @@ library usage.uuid_test;
 import 'package:test/test.dart';
 import 'package:usage/uuid/uuid.dart';
 
-main() => defineTests();
+void main() => defineTests();
 
 void defineTests() {
   group('uuid', () {


### PR DESCRIPTION
Add void declarations to methods with implicit dynamic returning void
values, which may be illegal in dart 2, but in either case, expresses
the current intent better.