### PR TITLE
bump package:usage to 3.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .packages
 .idea/
 .pub/
+.dart_tool/
 build/
 doc/api/
 pubspec.lock

--- a/.idea/usage.iml
+++ b/.idea/usage.iml
@@ -3,13 +3,9 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/example/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/src/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.0
+- bump our minimum SDK constraint to `>=2.0.0-dev.30`
+- change to using non-deprecated dart:convert constants
+
 ## 3.3.0
 - added a `close()` method to the `Analytics` class
 - change our minimum SDK from `1.24.0-dev` to `1.24.0` stable

--- a/lib/src/usage_impl_html.dart
+++ b/lib/src/usage_impl_html.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show JSON;
+import 'dart:convert' show jsonEncode, jsonDecode;
 import 'dart:html';
 
 import 'usage_impl.dart';
@@ -64,7 +64,7 @@ class HtmlPersistentProperties extends PersistentProperties {
   HtmlPersistentProperties(String name) : super(name) {
     String str = window.localStorage[name];
     if (str == null || str.isEmpty) str = '{}';
-    _map = JSON.decode(str);
+    _map = jsonDecode(str);
   }
 
   @override
@@ -78,7 +78,7 @@ class HtmlPersistentProperties extends PersistentProperties {
       _map[key] = value;
     }
 
-    window.localStorage[name] = JSON.encode(_map);
+    window.localStorage[name] = jsonEncode(_map);
   }
 
   @override

--- a/lib/src/usage_impl_io.dart
+++ b/lib/src/usage_impl_io.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show JSON, JsonEncoder;
+import 'dart:convert' show jsonDecode, JsonEncoder;
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
@@ -153,7 +153,7 @@ class IOPersistentProperties extends PersistentProperties {
     try {
       String contents = _file.readAsStringSync();
       if (contents.isEmpty) contents = '{}';
-      _map = JSON.decode(contents);
+      _map = jsonDecode(contents);
     } catch (_) {
       _map = {};
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,13 +3,13 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: usage
-version: 3.3.1-dev
+version: 3.4.0
 description: A Google Analytics wrapper for both command-line, web, and Flutter apps.
 homepage: https://github.com/dart-lang/usage
 author: Dart Team <misc@dartlang.org>
 
 environment:
-  sdk: '>=1.24.0 <2.0.0'
+  sdk: '>=2.0.0-dev.30 <2.0.0'
 
 dependencies:
   path: ^1.4.0


### PR DESCRIPTION
- bump our minimum SDK constraint to `>=2.0.0-dev.30`
- change to using non-deprecated dart:convert constants

@scheglov 