### PR TITLE
Update flutter usage example in the readme.md file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,14 +21,14 @@ to specify the documents directory in the constructor in order to tell the libra
 to save the analytics preferences:
 
 ```dart
-import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:usage/usage_io.dart';
 
-void main() {
+void main() async {
   final String UA = ...;
 
-  Analytics ga = new AnalyticsIO(UA, 'ga_test', '3.0',
-    documentsDirectory: PathProvider.getApplicationDocumentsDirectory());
+  Directory appDocDir = await getApplicationDocumentsDirectory();
+  Analytics ga = new AnalyticsIO(UA, 'ga_test', '3.0', documentDirectory: appDocDir);
   ...
 }
 ```


### PR DESCRIPTION
There was a typo in the property named documentDirectory, that was fixed
and updated the example to use path_provider package from Flutter Team.