### PR TITLE
Return valid type from Future.catchError.

### DIFF
--- a/lib/src/usage_impl.dart
+++ b/lib/src/usage_impl.dart
@@ -198,8 +198,8 @@ class AnalyticsImpl implements Analytics {
   Stream<Map<String, dynamic>> get onSend => _sendController.stream;
 
   @override
-  Future waitForLastPing({Duration? timeout}) {
-    Future f = Future.wait(_futures).catchError((e) => null);
+  Future<List<dynamic>> waitForLastPing({Duration? timeout}) {
+    var f = Future.wait(_futures).catchError((e) => []);
 
     if (timeout != null) {
       f = f.timeout(timeout, onTimeout: () => []);


### PR DESCRIPTION
An upcoming feature to the Dart analyzer [0] will report Future.catchError [1]
`onError` handlers which return values of invalid type. Currently this is not
reported because the `onError` handler function type cannot be accurately
expressed. An `onError` handler for `Future<T>.catchError` must be either
`FutureOr<T> Function(dynamic)` or `FutureOr<T> Function(dynamic, StackTrace)`.
In either case, the return type of the function is `FutureOr<T>`.

This CL corrects `onError` handler(s) to return a value of a valid type (typically `null`).

[0]: https://github.com/dart-lang/sdk/issues/35825
[1]: https://api.dart.dev/dev/2.12.0-149.0.dev/dart-async/Future/catchError.html