### PR TITLE
Force close the http-client on IOAnalytics.close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+- Force close the http client from `IOAnalytics.close()`.
+  This prevents lingering requests from making the application hang.
+
 ## 4.0.0
 - Publishing a null safe stable release.
 

--- a/lib/src/usage_impl_io.dart
+++ b/lib/src/usage_impl_io.dart
@@ -102,7 +102,11 @@ class IOPostHandler extends PostHandler {
   }
 
   @override
-  void close() => _client?.close(force: true);
+  void close() {
+    // Do a force close to ensure that lingering requests will not stall the
+    // program.
+    _client?.close(force: true);
+  }
 }
 
 JsonEncoder _jsonEncoder = JsonEncoder.withIndent('  ');

--- a/lib/src/usage_impl_io.dart
+++ b/lib/src/usage_impl_io.dart
@@ -102,7 +102,7 @@ class IOPostHandler extends PostHandler {
   }
 
   @override
-  void close() => _client?.close();
+  void close() => _client?.close(force: true);
 }
 
 JsonEncoder _jsonEncoder = JsonEncoder.withIndent('  ');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: usage
-version: 4.0.0
+version: 4.0.1
 description: A Google Analytics wrapper for command-line, web, and Flutter apps.
 homepage: https://github.com/dart-lang/usage
 


### PR DESCRIPTION
This is part of the solution of: https://github.com/dart-lang/sdk/issues/45235
