### PR TITLE
address a `null_argument_to_non_null_type` analysis issue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/checkout@v2
       - run: dart pub get
       - run: dart format --output=none --set-exit-if-changed .
-      - run: dart analyze
+      - run: dart analyze --fatal-infos
       - run: dart test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 4.1.0
+## 4.1.0-dev
 - Analytics hits can now be batched. See details in the documentation of the
   `AnalyticsIO` constructor.
+- Allow sendRaw to send Map<String, dynamic> (#161).
+- Address a `null_argument_to_non_null_type` analysis issue.
 
 ## 4.0.2
 - Fix a bug with the analytics ping throttling algorithm.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: usage
-version: 4.1.0
+version: 4.1.0-dev
 description: A Google Analytics wrapper for command-line, web, and Flutter apps.
 homepage: https://github.com/dart-lang/usage
 

--- a/test/web_test.dart
+++ b/test/web_test.dart
@@ -68,6 +68,6 @@ class MockRequestor {
     expect(sendData, isNotEmpty);
 
     sendCount++;
-    return Future.value();
+    return Future.value(HttpRequest());
   }
 }


### PR DESCRIPTION
- address a `null_argument_to_non_null_type` analysis issue
- tighten down the CI's analysis to catch all lints
- update the pubspec version to indicate that 4.1.0 hasn't been published yet
- update the changelog to capture the previous commit