### PR TITLE
enable dependabot support

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+# Dependabot configuration file.
+version: 2
+enable-beta-ecosystems: true
+
+updates:
+  # Enable weekly dependencies checks.
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    versioning-strategy: widen


### PR DESCRIPTION
- enable dependabot support

Note that it's not clear whether our pub integration here currently supports the `versioning-strategy: widen` option.
