### PR TITLE
Update dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,4 +9,3 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    versioning-strategy: widen


### PR DESCRIPTION
- change the dependabot update strategy from `widen` to `increase-if-necessary`

This likely matches what we want to do here. From reading the docs (https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy) and a bit of noodling, what I think dependabot will do in a few different cases is:

Version strategy | Current dep | New package version | Assumed dependabot change
-- | -- | -- | --
increase-if-necessary | ^3.0.0 | 3.1.0 | no change
widen | ^3.0.0 | 3.1.0 | no change
increase-if-necessary | ^3.0.0 | 4.0.0 | ^4.0.0
widen | ^3.0.0 | 4.0.0 | >=3.0.0 <5.0.0

- for apps, we likely want `increase-if-necessary`
- for many packages, we likely want `increase-if-necessary` (this matches what package maintainers are doing today)
- for highly dependent packages - ones heavily used by the ecosystem - we may want the `widen` strategy. This will prevent having very narrow ranges of packages that solve in the ecosystem, or, having to update many packages at once. Here, we might use the `widen` strategy, or, just use the depedabot PRs as a notification system, but plan to make most version ranges changes manually.

