### PR TITLE
update readme for deprecation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+# A CI configuration to auto-publish pub packages.
+
+name: Publish
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
+
+jobs:
+  publish:
+    if: ${{ github.repository_owner == 'dart-lang' }}
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.1
+
+- Updated the readme to indicate that this package is deprecated (see #185).
+- Require Dart 2.19.
+
 ## 4.1.0
 - Analytics hits can now be batched. See details in the documentation of the
   `AnalyticsIO` constructor.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A wrapper around Google Analytics for command-line, web, and Flutter apps.
 
 ## UPDATE: Intent to deprecate
 
-As an update for consumers of this package, we intent to deprecate
+As an update for consumers of this package, we intend to deprecate
 `package:usage`. https://github.com/dart-lang/usage/issues/185 has details and
 discussion, but briefly:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 A wrapper around Google Analytics for command-line, web, and Flutter apps.
 
+## UPDATE: Intent to deprecate
+
+As an update for consumers of this package, we intent to deprecate
+`package:usage`. https://github.com/dart-lang/usage/issues/185 has details and
+discussion, but briefly:
+
+- this package uses the older Universal Analytics protocol to record hits to
+  Google Analytics
+- Universal Analytics properties will stop processing new hits on July 1, 2023
+- this library does not support the newer GA4 protocol
+- we (the Dart team) originally built this package for our own use, but we're no
+  longer consuming it
+
+Clients who want to record hits to Google Analytics could:
+
+- for web clients, wrapping the gtags.js library is a good solution
+- for native clients, sending hits to the new protocol is not much more
+  difficult than sending HTTP POSTs to the right endpoint
+
+See also https://github.com/dart-lang/usage/issues/185 other potential
+remediations.
+
 ## For web apps
 
 To use this library as a web app, import the `usage_html.dart` library and

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,30 +1,6 @@
-include: package:lints/recommended.yaml
+include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
-    strict-casts: true
     strict-inference: true
     strict-raw-types: true
-
-linter:
-  rules:
-    - always_declare_return_types
-    - avoid_unused_constructor_parameters
-    - cancel_subscriptions
-    - directives_ordering
-    - lines_longer_than_80_chars
-    - literal_only_boolean_expressions
-    - missing_whitespace_between_adjacent_strings
-    - no_adjacent_strings_in_list
-    - no_runtimeType_toString
-    - omit_local_variable_types
-    - package_api_docs
-    - prefer_relative_imports
-    - prefer_single_quotes
-    - test_types_in_equals
-    - throw_in_finally
-    - type_annotate_public_apis
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_lambdas
-    - use_super_parameters

--- a/lib/src/usage_impl.dart
+++ b/lib/src/usage_impl.dart
@@ -49,7 +49,7 @@ class ThrottlingBucket {
     if (_lastReplenish + 1000 < now) {
       final inc = (now - _lastReplenish) ~/ 1000;
       drops = math.min(drops + inc, startingCount);
-      _lastReplenish += (1000 * inc);
+      _lastReplenish += 1000 * inc;
     }
   }
 }

--- a/lib/src/usage_impl_html.dart
+++ b/lib/src/usage_impl_html.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show jsonEncode, jsonDecode;
+import 'dart:convert' show jsonDecode, jsonEncode;
 import 'dart:html';
 
 import 'usage_impl.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,17 +3,17 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: usage
-version: 4.1.0
+version: 4.1.1
 description: A Google Analytics wrapper for command-line, web, and Flutter apps.
 repository: https://github.com/dart-lang/usage
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   meta: ^1.7.0
   path: ^1.8.0
 
 dev_dependencies:
-  lints: '>=1.0.0 <3.0.0'
+  dart_flutter_team_lints: ^1.0.0
   test: ^1.16.0

--- a/test/all.dart
+++ b/test/all.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library usage.all_test;
-
 import 'hit_types_test.dart' as hit_types_test;
 import 'usage_impl_io_test.dart' as usage_impl_io_test;
 import 'usage_impl_test.dart' as usage_impl_test;

--- a/test/hit_types_test.dart
+++ b/test/hit_types_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library usage.hit_types_test;
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -144,7 +142,8 @@ void defineTests() {
       var mock = createMock();
       await mock
           .sendException('foo bar (file:///Users/foobar/tmp/error.dart:3:13)');
-      expect(jsonDecode(mock.last)['exd'], 'foo bar (');
+      expect(
+          (jsonDecode(mock.last) as Map<String, dynamic>)['exd'], 'foo bar (');
     });
   });
 }

--- a/test/src/common.dart
+++ b/test/src/common.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library usage.common_test;
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -13,9 +11,12 @@ import 'package:usage/src/usage_impl.dart';
 AnalyticsImplMock createMock({Map<String, dynamic>? props}) =>
     AnalyticsImplMock('UA-0', props: props);
 
-void was(String m, String type) => expect(jsonDecode(m)['t'], type);
-void has(String m, String key) => expect(jsonDecode(m)[key], isNotNull);
-void hasnt(String m, String key) => expect(jsonDecode(m)[key], isNull);
+void was(String m, String type) =>
+    expect((jsonDecode(m) as Map<String, dynamic>)['t'], type);
+void has(String m, String key) =>
+    expect((jsonDecode(m) as Map<String, dynamic>)[key], isNotNull);
+void hasnt(String m, String key) =>
+    expect((jsonDecode(m) as Map<String, dynamic>)[key], isNull);
 
 class AnalyticsImplMock extends AnalyticsImpl {
   MockProperties get mockProperties => properties as MockProperties;

--- a/test/usage_impl_test.dart
+++ b/test/usage_impl_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library usage.impl_test;
-
 import 'package:test/test.dart';
 import 'package:usage/src/usage_impl.dart';
 

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library usage.usage_test;
-
 import 'package:test/test.dart';
 import 'package:usage/usage.dart';
 

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library usage.uuid_test;
-
 import 'package:test/test.dart';
 import 'package:usage/uuid/uuid.dart';
 


### PR DESCRIPTION
- Updated the readme to indicate that this package is deprecated (see #185).
- fix https://github.com/dart-lang/usage/issues/191
- Require Dart 2.19.
- update to package:dart_flutter_team_lints
