### PR TITLE
blast repo changes: dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,3 +16,7 @@ updates:
       interval: monthly
     labels:
       - autosubmit
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR contains changes created by the blast repo tool.

- `dependabot`